### PR TITLE
Add EnumSet serializer

### DIFF
--- a/graphsdk/src/main/java/com/microsoft/graph/serializer/EnumSetSerializer.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/serializer/EnumSetSerializer.java
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2015 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+package com.microsoft.graph.serializer;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.Iterator;
+
+/**
+ * Serializes and deserializes EnumSets
+ * The Graph service expects a single enum value as a comma-delimited string
+ * Here, we flatten the EnumSet to serialize the object
+ * and insert the response into an array to deserialize back to an EnumSet
+ */
+public class EnumSetSerializer {
+
+    /**
+     * Not available for instantiation.
+     */
+    private EnumSetSerializer() {
+    }
+
+    /**
+     * Deserializes a comma-delimited string of enum values
+     * @param type The type
+     * @param jsonStrToDeserialize The string to deserialize
+     * @return EnumSet of values
+     */
+    public static EnumSet deserialize(Type type, String jsonStrToDeserialize) {
+            Gson gson = new Gson();
+            String arrayString = "[" + jsonStrToDeserialize + "]";
+            return jsonStrToDeserialize == null ? null : (EnumSet) gson.fromJson(arrayString, type);
+    }
+
+    /**
+     * Serializes an EnumSet into a comma-delimited string
+     * @param src The source EnumSet
+     * @return A comma-delimited string of enum values
+     */
+    public static JsonPrimitive serialize(EnumSet src) {
+        String serializedString = "";
+
+        Iterator i = src.iterator();
+        while (i.hasNext()) {
+            serializedString += i.next().toString() + ",";
+        }
+        serializedString = serializedString.substring(0, serializedString.length()-1);
+        return new JsonPrimitive(serializedString);
+    }
+}

--- a/graphsdk/src/main/java/com/microsoft/graph/serializer/EnumSetSerializer.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/serializer/EnumSetSerializer.java
@@ -59,7 +59,7 @@ public class EnumSetSerializer {
      * @param src The source EnumSet
      * @return A comma-delimited string of enum values
      */
-    public static JsonPrimitive serialize(EnumSet src) {
+    public static JsonPrimitive serialize(EnumSet<?> src) {
         String serializedString = "";
 
         Iterator i = src.iterator();

--- a/graphsdk/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -37,6 +37,7 @@ import com.microsoft.graph.model.DateOnly;
 import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.util.Calendar;
+import java.util.EnumSet;
 import java.util.GregorianCalendar;
 
 /**
@@ -156,6 +157,32 @@ final class GsonFactory {
             }
         };
 
+        final JsonSerializer<EnumSet> enumSetJsonSerializer = new JsonSerializer<EnumSet>() {
+            @Override
+            public JsonElement serialize(final EnumSet src,
+                                         final Type typeOfSrc,
+                                         final JsonSerializationContext context) {
+                if (src == null) {
+                    return null;
+                }
+
+                return EnumSetSerializer.serialize(src);
+            }
+        };
+
+        final JsonDeserializer<EnumSet> enumSetJsonDeserializer = new JsonDeserializer<EnumSet>() {
+            @Override
+            public EnumSet deserialize(final JsonElement json,
+                                        final Type typeOfT,
+                                        final JsonDeserializationContext context) throws JsonParseException {
+                if (json == null) {
+                    return null;
+                }
+
+                return EnumSetSerializer.deserialize(typeOfT, json.getAsString());
+            }
+        };
+
         return new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
                 .registerTypeAdapter(Calendar.class, calendarJsonSerializer)
@@ -166,6 +193,8 @@ final class GsonFactory {
                 .registerTypeAdapter(byte[].class, byteArrayJsonSerializer)
                 .registerTypeAdapter(DateOnly.class, dateJsonSerializer)
                 .registerTypeAdapter(DateOnly.class, dateJsonDeserializer)
+                .registerTypeAdapter(EnumSet.class, enumSetJsonSerializer)
+                .registerTypeAdapter(EnumSet.class, enumSetJsonDeserializer)
                 .registerTypeAdapterFactory(new FallBackEnumTypeAdapter())
                 .create();
     }

--- a/graphsdk/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -162,7 +162,7 @@ final class GsonFactory {
             public JsonElement serialize(final EnumSet src,
                                          final Type typeOfSrc,
                                          final JsonSerializationContext context) {
-                if (src == null) {
+                if (src == null || src.size() == 0) {
                     return null;
                 }
 


### PR DESCRIPTION
Android does not handle isFlags out of the box, but we can serialize and deserialize into a set of enum objects. The templates would set the type to EnumSet in instances where isFlags=true and to Enum where isFlags=false or undefined