### PR TITLE
Don't prepend reserved enums with msgraph

### DIFF
--- a/graphsdk/src/main/java/com/microsoft/graph/extensions/Sensitivity.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/extensions/Sensitivity.java
@@ -31,7 +31,7 @@ public enum Sensitivity
     /**
     * private
     */
-    msgraph_private,
+    PRIVATE,
     /**
     * confidential
     */


### PR DESCRIPTION
Changing this value to uppercase resolves the conflict but allows the JSON to pass over the wire correctly