### PR TITLE
microsoftgraph/msgraph-sdk-android#106 fix ChunkedUpload limit

### DIFF
--- a/graphsdk/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
@@ -79,7 +79,7 @@ public class ChunkedUploadProvider<UploadType> {
     /**
      * The stream size.
      */
-    private final Long mStreamSize;
+    private final long mStreamSize;
 
     /**
      * The upload response handler.
@@ -103,7 +103,7 @@ public class ChunkedUploadProvider<UploadType> {
     public ChunkedUploadProvider(final UploadSession uploadSession,
                                  final IGraphServiceClient client,
                                  final InputStream inputStream,
-                                 final Long streamSize,
+                                 final long streamSize,
                                  final Class<UploadType> uploadTypeClass) {
         if (uploadSession == null) {
             throw new InvalidParameterException("Upload session is null.");

--- a/graphsdk/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
@@ -22,9 +22,6 @@
 
 package com.microsoft.graph.concurrency;
 
-
-import com.microsoft.graph.concurrency.ChunkedUploadResponseHandler;
-import com.microsoft.graph.concurrency.IProgressCallback;
 import com.microsoft.graph.extensions.ChunkedUploadRequest;
 import com.microsoft.graph.extensions.ChunkedUploadResult;
 import com.microsoft.graph.extensions.IGraphServiceClient;
@@ -82,7 +79,7 @@ public class ChunkedUploadProvider<UploadType> {
     /**
      * The stream size.
      */
-    private final int mStreamSize;
+    private final Long mStreamSize;
 
     /**
      * The upload response handler.
@@ -92,7 +89,7 @@ public class ChunkedUploadProvider<UploadType> {
     /**
      * The counter for how many bytes read from input stream.
      */
-    private int mReadSoFar;
+    private Long mReadSoFar;
 
     /**
      * Create the ChunkedUploadProvider
@@ -106,7 +103,7 @@ public class ChunkedUploadProvider<UploadType> {
     public ChunkedUploadProvider(final UploadSession uploadSession,
                                  final IGraphServiceClient client,
                                  final InputStream inputStream,
-                                 final int streamSize,
+                                 final Long streamSize,
                                  final Class<UploadType> uploadTypeClass) {
         if (uploadSession == null) {
             throw new InvalidParameterException("Upload session is null.");
@@ -125,7 +122,7 @@ public class ChunkedUploadProvider<UploadType> {
         }
 
         this.mClient = client;
-        this.mReadSoFar = 0;
+        this.mReadSoFar = 0L;
         this.mInputStream = inputStream;
         this.mStreamSize = streamSize;
         this.mUploadUrl = uploadSession.uploadUrl;

--- a/graphsdk/src/main/java/com/microsoft/graph/extensions/ChunkedUploadRequest.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/extensions/ChunkedUploadRequest.java
@@ -71,8 +71,8 @@ public class ChunkedUploadRequest {
                                 final byte[] chunk,
                                 final int chunkSize,
                                 final int maxRetry,
-                                final Long beginIndex,
-                                final Long totalLength) {
+                                final long beginIndex,
+                                final long totalLength) {
         this.mData = new byte[chunkSize];
         System.arraycopy(chunk, 0, this.mData, 0, chunkSize);
         this.mRetryCount = 0;

--- a/graphsdk/src/main/java/com/microsoft/graph/extensions/ChunkedUploadRequest.java
+++ b/graphsdk/src/main/java/com/microsoft/graph/extensions/ChunkedUploadRequest.java
@@ -71,8 +71,8 @@ public class ChunkedUploadRequest {
                                 final byte[] chunk,
                                 final int chunkSize,
                                 final int maxRetry,
-                                final int beginIndex,
-                                final int totalLength) {
+                                final Long beginIndex,
+                                final Long totalLength) {
         this.mData = new byte[chunkSize];
         System.arraycopy(chunk, 0, this.mData, 0, chunkSize);
         this.mRetryCount = 0;


### PR DESCRIPTION
Would be awesome if you could merge this and create a new release as soon as possible because currently, uploading files >2GB fails and our user aren't too excited about that 😅.


_Hint: To be able to build successfully this project on my machine, I added the following changes from the other PR locally: https://github.com/microsoftgraph/msgraph-sdk-android/pull/87/commits/739e3f1c0755f038205b7bf04d477f686edab4ca_